### PR TITLE
Implement Scope API Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@chakra-ui/react": "^2.8.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@tanstack/react-query": "^4.33.0",
+    "@tanstack/react-query-devtools": "^4.33.0",
     "@types/react": "^18.0.35",
     "@types/react-dom": "^18.0.11",
     "@types/react-router": "^5.1.20",

--- a/src/apis/scope/index.ts
+++ b/src/apis/scope/index.ts
@@ -1,0 +1,38 @@
+import { objToQueryString } from 'utils/objToQueryString';
+import instance from '..';
+import { ScopeParams, ScopeResponse } from './types';
+
+const scopeApi = {
+  /**
+   * 별점 높은 수강 후기 조회
+   */
+  reviews: async () =>
+    instance.get<ScopeResponse['reviews'], ScopeResponse['reviews']>(
+      '/lectures/scope/reviews',
+    ),
+  /**
+   * 강의력 좋은 강의 조회
+   */
+  lectures: async () =>
+    instance.get<ScopeResponse['lectures'], ScopeResponse['lectures']>(
+      '/lectures/scope/lectures',
+    ),
+  /**
+   * 최근 올라온 후기 조회
+   */
+  recent: async () =>
+    instance.get<ScopeResponse['recent'], ScopeResponse['recent']>(
+      '/review/recent',
+    ),
+  /**
+   * 후기 키워드 조회
+   */
+  keywords: async (scopeKeyword: ScopeParams['scopeKeyword']) => {
+    const query = scopeKeyword ? objToQueryString(scopeKeyword) : '';
+    return instance.get<ScopeResponse['keywords'], ScopeResponse['keywords']>(
+      `${'/review/keyword' + query}`,
+    );
+  },
+};
+
+export default scopeApi;

--- a/src/apis/scope/types/index.ts
+++ b/src/apis/scope/types/index.ts
@@ -1,0 +1,58 @@
+export type ScopeParams = {
+  scopeKeyword?: {
+    keyword?: string;
+  };
+};
+
+export type ScopeResponse = {
+  reviews: {
+    id: number;
+    lectureTitle: string;
+    userName: string;
+    createdDate: string;
+    score: number;
+    content: string;
+    tags: string;
+    source: string;
+  }[];
+  lectures: {
+    id: number;
+    source: string;
+    imageUrl: string;
+    title: string;
+    name: string;
+  }[];
+  recent: {
+    isAddLike: boolean;
+    review: {
+      reviewId: number;
+      score: number;
+      content: string;
+      createdDate: string;
+      tags: string;
+      likes: number;
+    };
+    lecture: {
+      lectureId: number;
+      source: string;
+      mainCategory: string;
+      title: string;
+      imageUrl: string;
+      name: string;
+    };
+    user: {
+      userId: number;
+      nickName: string;
+    };
+  }[];
+  keywords: {
+    id: number;
+    lectureTitle: string;
+    userName: string;
+    createdDate: string;
+    score: number;
+    content: string;
+    tags: string;
+    source: string;
+  }[];
+};

--- a/src/components/AppProvider/index.tsx
+++ b/src/components/AppProvider/index.tsx
@@ -1,27 +1,40 @@
 'use client';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
 import { CacheProvider as ChakraCacheProvider } from '@chakra-ui/next-js';
 import { ThemeProvider as EmotionThemeProvider } from '@emotion/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import theme from 'styles/theme';
 
 type AppProviderProps = {
-  children: ReactNode,
+  children: ReactNode;
 };
 
+const AppProvider = ({ children }: AppProviderProps) => {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+          },
+        },
+      }),
+  );
 
-const AppProvider = ({
-  children,
-}: AppProviderProps) => (
-  <EmotionThemeProvider theme={theme}>
-    <ChakraCacheProvider>
-      <ChakraProvider theme={theme}>
-        {children}
-      </ChakraProvider>
-    </ChakraCacheProvider>
-  </EmotionThemeProvider>
-);
+  return (
+    <QueryClientProvider client={queryClient}>
+      <EmotionThemeProvider theme={theme}>
+        <ChakraCacheProvider>
+          <ChakraProvider theme={theme}>{children}</ChakraProvider>
+        </ChakraCacheProvider>
+      </EmotionThemeProvider>
+      <ReactQueryDevtools />
+    </QueryClientProvider>
+  );
+};
 
 export type { AppProviderProps };
 export default AppProvider;

--- a/src/constants/querykeys.ts
+++ b/src/constants/querykeys.ts
@@ -1,0 +1,3 @@
+import { createQueryKeys } from '../utils/createQueryKeys';
+
+export const SCOPE_KEY = createQueryKeys('scope');

--- a/src/hooks/reactQuery/scope/query.ts
+++ b/src/hooks/reactQuery/scope/query.ts
@@ -1,0 +1,48 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import scopeApi from 'apis/scope';
+import { ScopeParams, ScopeResponse } from 'apis/scope/types';
+import { AxiosError } from 'axios';
+import { SCOPE_KEY } from 'constants/querykeys';
+
+export const useGetScopeReviews = (
+  options?: UseQueryOptions<ScopeResponse['reviews'], AxiosError>,
+) => {
+  return useQuery<ScopeResponse['reviews'], AxiosError>(
+    SCOPE_KEY.list(['reviews']),
+    () => scopeApi.reviews(),
+    { ...options },
+  );
+};
+
+export const useGetScopeLectures = (
+  options?: UseQueryOptions<ScopeResponse['lectures'], AxiosError>,
+) => {
+  return useQuery<ScopeResponse['lectures'], AxiosError>(
+    SCOPE_KEY.list(['lectures']),
+    () => scopeApi.lectures(),
+    { ...options },
+  );
+};
+
+export const useGetScopeRecent = (
+  options?: UseQueryOptions<ScopeResponse['recent'], AxiosError>,
+) => {
+  return useQuery<ScopeResponse['recent'], AxiosError>(
+    SCOPE_KEY.list(['recent']),
+    () => scopeApi.recent(),
+    { ...options },
+  );
+};
+
+export const useGetScopeKeyword = (
+  params?: ScopeParams['scopeKeyword'],
+  options?: UseQueryOptions<ScopeResponse['keywords'], AxiosError>,
+) => {
+  return useQuery<ScopeResponse['keywords'], AxiosError>(
+    SCOPE_KEY.list([{ ...params }]),
+    () => scopeApi.keywords(params),
+    {
+      ...options,
+    },
+  );
+};

--- a/src/utils/createQueryKeys.ts
+++ b/src/utils/createQueryKeys.ts
@@ -1,0 +1,12 @@
+// ref: https://www.zigae.com/react-query-key/
+// eslint-disable-next-line @typescript-eslint/comma-dangle
+export const createQueryKeys = <T extends string>(keyword: T) => {
+  const keys = {
+    all: [keyword] as const,
+    lists: () => [...keys.all, 'list'] as const,
+    list: (args: unknown[]) => [...keys.lists(), ...args] as const,
+    details: () => [...keys.all, 'detail'] as const,
+    detail: (args: unknown[]) => [...keys.details(), ...args] as const,
+  };
+  return keys;
+};

--- a/src/utils/objToQueryString.ts
+++ b/src/utils/objToQueryString.ts
@@ -1,0 +1,9 @@
+/**
+ * @example
+ * params = { last: true, capabilityId: 1, situation: true }
+ * console.log(objToQueryString(params)) // 'last=true&capabilityId=1&situation=true'
+ */
+export const objToQueryString = (obj: object) =>
+  Object.entries(obj)
+    .map(param => param.join('='))
+    .join('&');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,6 +2264,35 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tanstack/match-sorter-utils@^8.7.0":
+  version "8.8.4"
+  resolved "https://registry.yarnpkg.com/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz#0b2864d8b7bac06a9f84cb903d405852cc40a457"
+  integrity sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==
+  dependencies:
+    remove-accents "0.4.2"
+
+"@tanstack/query-core@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.33.0.tgz#7756da9a75a424e521622b1d84eb55b7a2b33715"
+  integrity sha512-qYu73ptvnzRh6se2nyBIDHGBQvPY1XXl3yR769B7B6mIDD7s+EZhdlWHQ67JI6UOTFRaI7wupnTnwJ3gE0Mr/g==
+
+"@tanstack/react-query-devtools@^4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-4.33.0.tgz#65d16e7248700445409c14821067f1dcbde2fb6f"
+  integrity sha512-6gegkuDmOoiY5e6ZKj1id48vlCXchjfE/6tIpYO8dFlVMQ7t1bYna/Ce6qQJ69+kfEHbYiTTn2lj+FDjIBH7Hg==
+  dependencies:
+    "@tanstack/match-sorter-utils" "^8.7.0"
+    superjson "^1.10.0"
+    use-sync-external-store "^1.2.0"
+
+"@tanstack/react-query@^4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.33.0.tgz#e927b0343a6ecaa948fee59e9ca98fe561062638"
+  integrity sha512-97nGbmDK0/m0B86BdiXzx3EW9RcDYKpnyL2+WwyuLHEgpfThYAnXFaMMmnTDuAO4bQJXEhflumIEUfKmP7ESGA==
+  dependencies:
+    "@tanstack/query-core" "4.33.0"
+    use-sync-external-store "^1.2.0"
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -2863,6 +2892,13 @@ cookies-next@^2.1.2:
     "@types/cookie" "^0.4.1"
     "@types/node" "^16.10.2"
     cookie "^0.4.0"
+
+copy-anything@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"
+  integrity sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==
+  dependencies:
+    is-what "^4.1.8"
 
 copy-to-clipboard@3.3.3:
   version "3.3.3"
@@ -4015,6 +4051,11 @@ is-weakref@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
+is-what@^4.1.8:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.15.tgz#de43a81090417a425942d67b1ae86e7fae2eee0e"
+  integrity sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==
+
 is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
@@ -4734,6 +4775,11 @@ regjsparser@^0.9.1:
   dependencies:
     jsesc "~0.5.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -4969,6 +5015,13 @@ stylis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
+
+superjson@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.13.1.tgz#a0b6ab5d22876f6207fcb9d08b0cb2acad8ee5cd"
+  integrity sha512-AVH2eknm9DEd3qvxM4Sq+LTCkSXE2ssfh1t11MHMXyYXFQyQ1HLgVvV+guLTsaQnJU3gnaVo34TohHPulY/wLg==
+  dependencies:
+    copy-anything "^3.0.2"
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -5233,6 +5286,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
### ⛳️ Task
react-query를 세팅했습니다.
query 키를 관리하는 createQueryKeys util을 구현했습니다.
object를 queryString으로 변환하는 util을 구현했습니다.
Scope 페이지 axios api를 구현했습니다.
Scope 페이지 Query를 구현했습니다.
### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
